### PR TITLE
Fix 2x image processing

### DIFF
--- a/.changeset/eighty-starfishes-float.md
+++ b/.changeset/eighty-starfishes-float.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/masher": patch
+---
+
+Tweak -2x support

--- a/src/get-file-info.ts
+++ b/src/get-file-info.ts
@@ -8,6 +8,7 @@ import { log } from "./log"
 
 export interface FileInfo {
   path: string
+  originalPath: string
   filename: string
   ext: OutputTypes
   width: number
@@ -41,8 +42,11 @@ export function getFileInfo(path: string): FileInfo | null {
 
   const ratio = width / height
 
+  const originalPath = `${dir}/${name}.${type}`
+
   return {
     path: dir,
+    originalPath,
     filename,
     ext: type,
     width,

--- a/src/process-defined-image.ts
+++ b/src/process-defined-image.ts
@@ -1,4 +1,4 @@
-import { join, resolve, relative } from "node:path"
+import { resolve, relative } from "node:path"
 
 import type { Cache, CacheItem, Config, OutputTypes } from "./types"
 import { FileInfo } from "./get-file-info"
@@ -6,12 +6,12 @@ import { addToQueue } from "./add-to-queue"
 
 export function processDefinedImage(
   hash: string,
-  { ext, path, is2x, filename, width, height }: FileInfo,
+  { ext, path, originalPath, is2x, filename, width, height }: FileInfo,
   cache: Cache,
   config: Config
 ) {
   const outputTypes: OutputTypes[] = [ext]
-  const fullPath = join(path, filename + "." + ext)
+  const fullPath = originalPath
 
   if (ext === "png") outputTypes.push("webp")
 


### PR DESCRIPTION
<!-- use this as template for your PR title -->

# Fix: Fix `-2x` image processing

## Description

Previously, only 1x images were being processed. The path we were passing to `processDefinedImage` was not taking -2x images into account, so sharp would only look for 1x versions and subsequently error because we were only giving it `-2x` versions.

## Solution

Update the `fullPath` variable to be the result of `path + filename + extension`, where `filename` contains the original/raw `-2x` suffix.

## Additional Notes

This could probably be cleaner, I was in a hurry to get this out by end of day — please feel free to suggest a more elegant way to pass this information down.