### PR TITLE
Fixing the cache keys to make them relative to the project root

### DIFF
--- a/.changeset/eighty-crabs-shout.md
+++ b/.changeset/eighty-crabs-shout.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/masher": minor
+---
+
+Updating the file paths to be relative to the project root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/masher",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/masher",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@changesets/changelog-github": "~0.5.0",

--- a/src/check-all.ts
+++ b/src/check-all.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 
 import { glob } from "glob"
 
@@ -11,7 +11,7 @@ export function checkAll(cache: Cache, config: Config) {
 
   // check for files deleted while masher wasn't running
   Object.keys(cache).forEach((cacheFile) => {
-    if (!files.includes(cacheFile)) {
+    if (!files.includes(resolve(cacheFile))) {
       processPath(cacheFile, ACTION_TYPE.delete, config, cache)
     }
   })

--- a/src/delete-files.ts
+++ b/src/delete-files.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path"
+
 import fse from "fs-extra"
 
 import type { Cache } from "./types"
@@ -13,7 +15,8 @@ export function deleteFiles(path: string, cache: Cache) {
     const filesToDelete = cache[path]?.generatedFiles || []
 
     filesToDelete.forEach((d) => {
-      fse.remove(d)
+      d = resolve(d)
+      fse.unlink(d)
       log(LOG_TYPE.deleted, d)
     })
 

--- a/src/delete-files.ts
+++ b/src/delete-files.ts
@@ -16,8 +16,15 @@ export function deleteFiles(path: string, cache: Cache) {
 
     filesToDelete.forEach((d) => {
       d = resolve(d)
-      fse.unlink(d)
-      log(LOG_TYPE.deleted, d)
+      if (fse.existsSync(d)) {
+        fse.unlink(d)
+        log(LOG_TYPE.deleted, d)
+      } else {
+        log(
+          LOG_TYPE.error,
+          `Tried to delete ${d} but failed. It's probably nothing, but you might want to check.`
+        )
+      }
     })
 
     delete cache[path]

--- a/src/get-file-info.ts
+++ b/src/get-file-info.ts
@@ -1,4 +1,5 @@
-import { parse } from "node:path"
+import { parse, relative } from "node:path"
+import { cwd } from "node:process"
 
 import sizeOf from "image-size"
 
@@ -17,32 +18,33 @@ export interface FileInfo {
   ratio: number
 }
 
-export function getFileInfo(path: string): FileInfo | null {
+export function getFileInfo(PATH: string): FileInfo | null {
   let width = null
   let height = null
   let type: OutputTypes | null = null
 
   try {
-    const size = sizeOf(path)
+    const size = sizeOf(PATH)
 
     width = size.width!
     height = size.height!
     type = size.type as OutputTypes
   } catch (err) {
-    log(LOG_TYPE.error, "Could not load file", path)
+    log(LOG_TYPE.error, "Could not load file", PATH)
 
     return null
   }
 
-  const { name, dir } = parse(path)
+  const { name, dir } = parse(PATH)
 
-  const is2x = path.includes("-x2") || path.includes("-2x") || path.includes("@2x")
+  const is2x = PATH.includes("-x2") || PATH.includes("-2x") || PATH.includes("@2x")
 
   const filename = name.replace("-2x", "")
 
   const ratio = width / height
 
-  const originalPath = `${dir}/${name}.${type}`
+  // const originalPath = `${dir}/${name}.${type}`
+  const originalPath = "./" + relative(cwd(), `${dir}/${name}.${type}`)
 
   return {
     path: dir,

--- a/src/has-file-changed.ts
+++ b/src/has-file-changed.ts
@@ -1,6 +1,10 @@
+import { relative } from "node:path"
+import { cwd } from "node:process"
+
 import type { Cache } from "./types"
 
 export function hasFileChanged(cache: Cache, path: string, hash: string): boolean {
+  path = "./" + relative(cwd(), path)
   // Not in cache
   if (!cache[path]) return true
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import { rmdirSync } from "node:fs"
+import { relative } from "node:path"
+import { cwd } from "node:process"
 
 import watch from "node-watch"
 
@@ -72,7 +74,7 @@ if (args.watch) {
       loadCache(config)
     }
 
-    const path = name
+    const path = "./" + relative(cwd(), name)
 
     if (evt === "remove") {
       processPath(path, ACTION_TYPE.delete, config, cache)

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ if (QUEUE.length === 0 && !args.watch) {
 
   if (args.force) saveRegister(cache, config)
 
+  saveCache(cache, config)
+
   process.exit(0)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { resolve } from "node:path"
 import { rmdirSync } from "node:fs"
 
 import watch from "node-watch"
@@ -71,7 +70,7 @@ if (args.watch) {
       loadCache(config)
     }
 
-    const path = resolve(".", name)
+    const path = name
 
     if (evt === "remove") {
       processPath(path, ACTION_TYPE.delete, config, cache)

--- a/src/process-path.ts
+++ b/src/process-path.ts
@@ -29,7 +29,11 @@ export function processPath(
         // files from the cache that were in that folder
         Object.keys(cache)
           .filter((p) => p.includes(path))
-          .forEach((p) => deleteFiles(p, cache))
+          .forEach((p) => {
+            console.log("directory")
+            console.log(p)
+            deleteFiles(p, cache)
+          })
       } else {
         if (cache[path]) {
           deleteFiles(path, cache)

--- a/src/process-queue.ts
+++ b/src/process-queue.ts
@@ -1,5 +1,6 @@
-import { join } from "node:path"
+import { join, relative } from "node:path"
 import { log } from "console"
+import { cwd } from "node:process"
 
 import fse from "fs-extra"
 import sharp from "sharp"
@@ -55,7 +56,8 @@ export async function processQueue(cache: Cache) {
           break
       }
 
-      const path = newImagePath + "." + type
+      // const path = newImagePath + "." + type
+      const path = "./" + relative(cwd(), `${newImagePath}.${type}`)
 
       outputs.push(image.toFile(path))
       cache[item.path].generatedFiles.push(path)


### PR DESCRIPTION
## Description

Resolves the issue with the keys not working cross-machine, as absolute paths are obviously different.

Updated the queue generation to create and use relative file paths.
Updated the file testing to be able to parse relative paths.

Fixes #11 

